### PR TITLE
add readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt
+        

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,23 +1,13 @@
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
 version: 2
 
-# Set the OS, Python version, and other tools you might need
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.12"
 
-# Build documentation in the "docs/" directory with Sphinx
-sphinx:
-   configuration: docs/conf.py
+mkdocs:
+  configuration: mkdocs.yml
 
-# Optionally, but recommended,
-# declare the Python requirements required to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
-        
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,12 @@
+# CLI
+
+```bash
+$ bbml runs
+NAME              DATE                 DURATION  STEPS  TAGS
+----------------------------------------------------------------
+resnet_cifar10    2026-03-10 14:22:01    13m 46s     10  pytorch, cifar10
+lstm_nlp          2026-03-10 11:05:33     4m 12s      5  keras
+
+$ bbml show resnet_cifar10
+$ bbml clean
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,12 @@
+# Contributing
+
+See the [Contributing Guidelines](https://github.com/sxa-lab/blackboxml/blob/main/.github/CONTRIBUTING.MD) to get started. Bug reports, feature requests, and pull requests are welcome.
+
+- [Bug reports](https://github.com/sxa-lab/blackboxml/blob/main/.github/ISSUE_TEMPLATE/bug_report.md)
+- [Feature requests](https://github.com/sxa-lab/blackboxml/blob/main/.github/ISSUE_TEMPLATE/feature_request.md)
+- [Security policy](https://github.com/sxa-lab/blackboxml/blob/main/.github/SECURITY.MD)
+- [Code of conduct](https://github.com/sxa-lab/blackboxml/blob/main/.github/CODE_OF_CONDUCT.MD)
+
+## License
+
+[Apache License 2.0](https://github.com/sxa-lab/blackboxml/blob/main/LICENSE) — maintained by [SxA Lab](https://github.com/sxa-lab)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# blackboxml
+
+[![PyPI version](https://badge.fury.io/py/blackboxml.svg)](https://badge.fury.io/py/blackboxml) [![Python Version](https://img.shields.io/pypi/pyversions/blackboxml.svg)](https://pypi.org/project/blackboxml/) [![Tests](https://github.com/sxa-lab/blackboxml/actions/workflows/test.yml/badge.svg)](https://github.com/sxa-lab/blackboxml/actions/workflows/test.yml) [![Downloads](https://static.pepy.tech/badge/blackboxml)](https://pepy.tech/project/blackboxml)
+
+ML experiment tracking. Local, lightweight, framework-agnostic.
+
+Works with PyTorch, Keras, scikit-learn, or plain Python.
+
+## Install
+
+```bash
+pip install blackboxml
+pip install blackboxml[keras]  # optional TensorFlow support
+```

--- a/docs/logged.md
+++ b/docs/logged.md
@@ -1,0 +1,26 @@
+# What gets logged
+
+Each run saves to `blackboxml_logs/<name>_<timestamp>/run.json`:
+
+```json
+{
+  "name": "resnet_cifar10",
+  "tags": ["pytorch", "cifar10"],
+  "environment": {
+    "git_commit": "a3f91bc",
+    "git_dirty": false,
+    "python": "3.11.2",
+    "torch": "2.3.0",
+    "hostname": "lab-gpu-01"
+  },
+  "start": "2026-03-10T14:22:01",
+  "end": "2026-03-10T14:35:47",
+  "duration_seconds": 826,
+  "steps": [
+    {"loss": 0.842, "acc": 0.65},
+    {"loss": 0.671, "acc": 0.78}
+  ]
+}
+```
+
+Git commit, Python version, framework versions, and hostname are captured automatically.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,38 @@
+# Usage
+
+### @track
+
+```python
+from blackboxml import track, MetricStore
+
+@track(name="resnet_cifar10", tags=["pytorch", "cifar10"])
+def train():
+    metrics = MetricStore()
+    for epoch in range(10):
+        metrics.reset()
+        for batch in dataloader:
+            loss, acc = train_step(batch)
+            metrics.update({"loss": loss, "acc": acc}, n=len(batch))
+        yield metrics.compute()
+
+train()
+```
+
+### Run context manager
+
+```python
+from blackboxml import Run
+
+with Run(name="resnet_cifar10", tags=["pytorch"]) as run:
+    for epoch in range(10):
+        run.log({"loss": train_one_epoch(), "epoch": epoch})
+```
+
+### Keras callback
+
+```python
+from blackboxml.callback import BlackBoxCallback
+
+model.fit(x_train, y_train, epochs=10,
+          callbacks=[BlackBoxCallback(name="lstm_nlp", tags=["keras"])])
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,25 @@
+site_name: blackboxml
+site_description: ML experiment tracking. Local, lightweight, framework-agnostic.
+site_url: https://blackboxml.readthedocs.io
+repo_url: https://github.com/sxa-lab/blackboxml
+repo_name: sxa-lab/blackboxml
+
+theme:
+  name: material
+  palette:
+    primary: blue grey
+  features:
+    - navigation.sections
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Usage: usage.md
+  - CLI: cli.md
+  - What gets logged: logged.md
+  - Contributing: contributing.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences


### PR DESCRIPTION
Sets up MkDocs with Material theme for ReadTheDocs. Switches from the Sphinx config to MkDocs, adds docs pages mirroring the README content.